### PR TITLE
[Utils] Add Partially Mapped Crossover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![npm bundle size (version)](https://img.shields.io/bundlephobia/minzip/chromosome-js/0.3.0)
+![npm bundle size (version)](https://img.shields.io/bundlephobia/minzip/chromosome-js/0.4.0)
 
 # ChromosomeJS 🐒
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,11 +20,6 @@
     "analyze": "size-limit --why"
   },
   "peerDependencies": {},
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsdx lint"
-    }
-  },
   "name": "chromosome-js",
   "author": "Angel Paredes Barato",
   "module": "dist/chromesome-js.esm.js",

--- a/src/lib/crossover/index.ts
+++ b/src/lib/crossover/index.ts
@@ -52,3 +52,51 @@ export const xPointCrossOver= (x: number) : CrossoverFunction => (genome1, genom
 export const twoPointCrossOver = xPointCrossOver(2)
 
 export const onePointCrossOver = xPointCrossOver(1)
+
+
+
+type MapToEqual = {
+    [k in string | number]: string | number;
+};
+/* Partially Mapped Crossover Operator */
+export const pmxCrossover : CrossoverFunction = (genome1, genome2) => {
+    let mapOffspring1 : MapToEqual= {}
+    let mapOffspring2 : MapToEqual= {}
+
+    const [point1, point2] = getRandomFixPoints(genome1.length, 2)
+
+    if (!(Array.isArray(genome1) && Array.isArray(genome2))) {
+        throw TypeError("You cant use PMX with object genomes")
+    }
+
+    let offspring = [Array.from(genome1), Array.from(genome2)]
+
+    for (let i = point1; i < point2; i++) {
+        offspring[0][i] = genome2[i]
+        mapOffspring1[genome2[i]] = genome1[i]
+
+        offspring[1][i] = genome1[i]
+        mapOffspring2[genome1[i]] = genome2[i]
+    }
+
+    // Copy values as they are and substitute numbers that are in the map
+    for (let i = 0; i < point1; i++) {
+        while (offspring[0][i] in mapOffspring1) {
+            offspring[0][i] = mapOffspring1[offspring[0][i]]
+        }
+        while (offspring[1][i] in mapOffspring2) {
+            offspring[1][i] = mapOffspring2[offspring[1][i]]
+        }
+    }
+
+    for (let i = point2; i < genome1.length; i++) {
+        while (offspring[0][i] in mapOffspring1) {
+            offspring[0][i] = mapOffspring1[offspring[0][i]]
+        }
+        while (offspring[1][i] in mapOffspring2) {
+            offspring[1][i] = mapOffspring2[offspring[1][i]]
+        }
+    }
+
+        return offspring as [Genome, Genome]
+}

--- a/test/lib/crossover.spec.ts
+++ b/test/lib/crossover.spec.ts
@@ -1,6 +1,6 @@
 import { mockRandom, resetMockRandom } from 'jest-mock-random';
 import { forAll } from '../test/forAll';
-import { onePointCrossOver, twoPointCrossOver } from '../../src/lib/crossover';
+import { onePointCrossOver, pmxCrossover, twoPointCrossOver } from '../../src/lib/crossover';
 
 describe('onePointCrossOver', () => {
     const ONEPOINT_SAMPLES = [
@@ -67,4 +67,43 @@ describe('twoPointCrossOver', () => {
             [4, 2, 6],
         ]);
     });
+
+    describe('pmxCrossover', () => {
+        const TWOPOINT_SAMPLES = [
+            {ramdomValues: [3 / 8, 2 / 4], expected: [[3, 4, 2, 1, 6, 8, 7, 5], [4, 8, 5, 2, 7, 1, 3, 6]]},
+            {ramdomValues: [3 / 8, 1 / 4], expected: [[ 3, 4, 8, 1, 6, 2, 7, 5], [4, 1, 5, 2, 7, 8, 3, 6]]},
+        ];
+        forAll(TWOPOINT_SAMPLES, ({ramdomValues, expected}) => {
+            it('performs a cross over on two points in the gene list for ramdomValues ', () => {
+                mockRandom(ramdomValues);
+
+                const children = pmxCrossover(
+                    [3, 4, 8, 2, 7, 1, 6, 5], [4, 2, 5, 1, 6, 8, 3, 7]
+                );
+
+                expect(children).toEqual(expected);
+                resetMockRandom();
+            });
+        });
+
+        it('throws an error if we try to use genome objects', () => {
+            const executeError = () => pmxCrossover({a: 1, b: 2}
+                , {a: 1, b: 2});
+
+            expect(executeError).toThrow(TypeError);
+        })
+
+        it('returns the same Set of characters as the parents, always', () => {
+            const parent1 = new Set([3, 4, 8, 2, 7, 1, 6, 5])
+            const parent2 = new Set([4, 2, 5, 1, 6, 8, 3, 7])
+
+            const children = pmxCrossover(Array.from(parent1), Array.from(parent2));
+
+            const ChildrenSet1 = new Set(children[0] as Array<any>)
+            const ChildrenSet2 = new Set(children[1] as Array<any>)
+
+            expect(ChildrenSet1.size).toBe(parent1.size);
+            expect(ChildrenSet2.size).toBe(parent2.size);
+        })
+    })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,7 +4242,7 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   dependencies:
@@ -5288,6 +5288,18 @@ node-notifier@^6.0.0:
     semver "^6.3.0"
     shellwords "^0.1.1"
     which "^1.3.1"
+
+node-notifier@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.2.0"
+    semver "^7.3.2"
+    shellwords "^0.1.1"
+    uuid "^8.3.0"
+    which "^2.0.2"
 
 node-releases@^1.1.66, node-releases@^1.1.67:
   version "1.1.67"
@@ -7599,6 +7611,11 @@ utils-merge@1.0.1:
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"


### PR DESCRIPTION
As described in https://books.google.es/books?hl=en&lr=&id=lI17AgAAQBAJ&oi=fnd&pg=PA154&ots=0Mj3gaP20w&sig=gEu51WnrZcOj-OwYklUyX-EAWN8&redir_esc=y#v=onepage&q&f=false

This crossover function allows for a safe crossover over a fixed set of genotypes in the genome, like in the TSP, where we know that each solution generated should be a combination of a Set of routes.