### PR TITLE
[Utils] feat: Add endCondition and preventUIBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ ChromosomeJS offers a serie of utility functions to help out with different part
 - ```xPointCrossover - (x: number) => CrossoverFunction``` - Create X amount of fixed points and swap values between 2 individuals 
 - ```onePointCrossover - CrossoverFunction``` - Two individuals generate two offsprings by swapping values at a random point.
 - ```twoPointCrossover - CrossoverFunction``` - Same as one point crossover but with two points
+- ```pmxCrossover - CrossoverFunction``` - Operator which is a bit more optimal for some GA problems when you need a permutation of a set of values in the genome
+- ```cycleCrossover - CrossoverFunction``` - Operator which is a bit more optimal for some GA problems when you need a permutation of a set of values in the genome. ([Better performance than PMX for some problems](https://arxiv.org/pdf/1203.3097.pdf))
 
 #### Mutation `MutationFunction = (probability: number, genome: Genome) => Genome`
 

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "peoplenarthax",
+  "license": "MIT",
+  "scripts": {
+    "start": "tsc src/index.ts && node src/index.js"
+  },
+  "dependencies": {
+    "chromosome-js": "^0.6.0"
+  }
+}

--- a/examples/hello-world/src/index.js
+++ b/examples/hello-world/src/index.js
@@ -1,0 +1,55 @@
+"use strict";
+exports.__esModule = true;
+var chromosome_js_1 = require("chromosome-js");
+var printPopulationData = function (population, generationNumber) {
+    console.log("----- Generation number:" + generationNumber + " -----");
+    console.log('BEST INDIVIDUAL:\n', population[0].genome.join(''));
+    console.log(population[0].fitness);
+};
+var randomChar = function () { return String.fromCharCode(chromosome_js_1.randomInRange(0, 255)); }; //32. 130 reduced space
+var generateRandomStringOf = function (amount) { return function () { return Array.from({ length: amount }, randomChar); }; };
+var STRING_GOAL = 'chromosome-js'.split('');
+// Genotypes creates a blueprint function for generating individuals
+var genotype = generateRandomStringOf(STRING_GOAL.length);
+// Fitness is a function that can evaluate the result of the genotype
+var fitness = function (goal) { return function (gene) {
+    var total = 0;
+    for (var i = 0; i < gene.length; i += 1) {
+        total += Math.abs(gene[i].charCodeAt(0) - goal[i].charCodeAt(0));
+    }
+    return -total;
+}; };
+var flipCharMutation = function (mutationProbability, gene) {
+    if (Math.random() > mutationProbability) {
+        return gene;
+    }
+    var newGenome = Array.from(gene);
+    var index = Math.floor(Math.random() * gene.length);
+    var upOrDown = Math.random() <= 0.5 ? -1 : 1;
+    var newChar = String.fromCharCode(gene[index].charCodeAt(0) + upOrDown);
+    newGenome[index] = newChar;
+    return newGenome;
+};
+var config = {
+    populationSize: 200,
+    mutationProbability: 0.2,
+    crossoverProbability: 0.4,
+    individualValidation: false,
+    generations: 9999,
+    preventUIBlock: true,
+    endCondition: function (_a) {
+        var first = _a[0];
+        return first.genome.join('') === STRING_GOAL.join('');
+    }
+};
+chromosome_js_1.GARunner({
+    seed: genotype,
+    fitness: fitness(STRING_GOAL),
+    mutation: flipCharMutation,
+    crossover: chromosome_js_1.onePointCrossOver,
+    selection: chromosome_js_1.selectRoulette,
+    config: config,
+    hooks: {
+        onGeneration: printPopulationData
+    }
+});

--- a/examples/hello-world/src/index.ts
+++ b/examples/hello-world/src/index.ts
@@ -1,0 +1,64 @@
+import {
+    GARunner,
+    Genome,
+    Individual,
+    MutationFunction,
+    onePointCrossOver,
+    randomInRange,
+    selectRoulette
+} from "chromosome-js";
+
+const printPopulationData = ( population: Individual[], generationNumber: number) => {
+    console.log(`----- Generation number:${generationNumber} -----`);
+    console.log('BEST INDIVIDUAL:\n', population[0].genome.join(''));
+    console.log(population[0].fitness);
+};
+
+const randomChar = () => String.fromCharCode(randomInRange(0, 255)); //32. 130 reduced space
+const generateRandomStringOf = (amount: number) => () => Array.from({length: amount}, randomChar)
+
+const STRING_GOAL = 'chromosome-js'.split('')
+
+// Genotypes creates a blueprint function for generating individuals
+const genotype = generateRandomStringOf(STRING_GOAL.length);
+
+// Fitness is a function that can evaluate the result of the genotype
+const fitness = (goal: string[]) => (gene: Genome) => {
+    let total = 0;
+    for (let i = 0; i < gene.length; i += 1) {
+        total += Math.abs(gene[i].charCodeAt(0) - goal[i].charCodeAt(0));
+    }
+    return -total;
+};
+
+const flipCharMutation : MutationFunction = (mutationProbability, gene) => {
+    if (Math.random() > mutationProbability) { return gene; }
+    let newGenome : string[] = Array.from(gene as string[])
+    const index = Math.floor(Math.random() * gene.length);
+    const upOrDown = Math.random() <= 0.5 ? -1 : 1;
+    const newChar = String.fromCharCode((gene[index] as string).charCodeAt(0) + upOrDown);
+    newGenome[index] = newChar
+
+    return newGenome
+};
+
+    const config = {
+        populationSize: 200,
+        mutationProbability: 0.2,
+        crossoverProbability: 0.4,
+        individualValidation: false,
+        generations: 9999,
+        preventUIBlock: false,
+        endCondition: ([first]: Individual[]) => first.genome.join('') === STRING_GOAL.join('')
+    }
+
+    GARunner({
+            seed: genotype,
+            fitness:fitness(STRING_GOAL),
+            mutation: flipCharMutation,
+            crossover: onePointCrossOver,
+            selection: selectRoulette,
+            config,
+            hooks: {
+                onGeneration: printPopulationData
+            } })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -3,18 +3,18 @@
  * if you need to hook to different parts or change the algorithm
  * you can overwrite the step method in GeneticAlgorithm class
  */
-
 import { GeneticAlgorithm, GeneticAlgorithmConstructor } from './GeneticAlgorithm'
 
  export const GARunner = async <T>(parameters: GeneticAlgorithmConstructor<T>) => {
 	const geneticAlgorithm = new GeneticAlgorithm(parameters)
+	let done = false
 
-	for (let i = 0; i < parameters.config.generations; i++) {
-		/*
-		*	We rather use setTimeout over promises due to problems with
-		* 	promises being continuosly solve block the miniTask queue preventing
-		*	macro task queue (like UI) from working
-		*/
-		setTimeout(() => geneticAlgorithm.step(), 0)
+	for (let i = 0; i < parameters.config.generations && !done; i++) {
+	// 	/*
+	// 	*	We rather use setTimeout over promises due to problems with
+	// 	* 	promises being continuosly solve block the miniTask queue preventing
+	// 	*	macro task queue (like UI) from working
+	// 	*/
+		done = await geneticAlgorithm.step()
 	}
  }


### PR DESCRIPTION
This PR adds a couple of features to the runner:

- endCondition : Function that evaluates all the current population to check if we should stop the GA before the specified number of generations (E.g arrived to a optimal/suboptimal condition of our election). In case is empty, we run until the end of generations
- preventUIBlock: Before by default we use `setTimeout` in each generation to leverage heavy operations from the microtask stack in the browser, this just prevents the browser from freezing interaction (otherwise we cannot click or see re renders of the page until generations are done). If set to false we allow UIBlocking (for example in node environments, by the moment, the most optimal solution is to use the default (`preventUIBlock: false`)

Add a simple hello world example using the GARunner